### PR TITLE
Added support for SIMD.jl; WIP

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,39 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SIMD]]
+deps = ["InteractiveUtils", "Test"]
+git-tree-sha1 = "c6f6f4a8103e69c66b06def75f04904f72111c51"
+uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
+version = "2.2.0"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -2,11 +2,14 @@ name = "SLEEF"
 uuid = "3e6341c9-01f6-5312-b33f-f8894a2e817a"
 license = "MIT"
 repo = "https://github.com/musm/SLEEF.jl.git"
-version = "v0.5.1"
+version = "0.5.1"
+
+[deps]
+SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","Printf"]
+test = ["Test", "Printf"]

--- a/src/SLEEF.jl
+++ b/src/SLEEF.jl
@@ -8,6 +8,28 @@ module SLEEF
 
 using Base.Math: uinttype, @horner, exponent_bias, exponent_mask, significand_bits, IEEEFloat, exponent_raw_max
 
+using SIMD
+using SIMD: vifelse
+
+const FloatType64 = Union{Float64,Vec{<:Any,Float64}}
+const FloatType32 = Union{Float32,Vec{<:Any,Float32}}
+const FloatType = Union{FloatType64,FloatType32}
+const IntegerType64 = Union{Int64,Vec{<:Any,Int64}}
+const IntegerType32 = Union{Int32,Vec{<:Any,Int32}}
+const IntegerType = Union{IntegerType64,IntegerType32}
+
+EquivalentInteger(::Type{Float64}) = Int64
+EquivalentInteger(::Type{Float32}) = Int32
+EquivalentInteger(::Type{Vec{N,Float64}}) where N = Vec{N,Int64}
+EquivalentInteger(::Type{Vec{N,Float32}}) where N = Vec{N,Int32}
+
+@generated function Base.unsafe_trunc(::Type{I}, x::Vec{N,T}) where {N,T,I}
+    quote
+        $(Expr(:meta,:inline))
+        Vec{$N,$I}($(Expr(:tuple, [:(Core.VecElement(unsafe_trunc($I, x[$n]))) for n ∈ 1:N]...)))
+    end
+end
+
 ## constants
 
 const MLN2  = 6.931471805599453094172321214581765680755001343602552541206800094933936219696955e-01 # log(2)

--- a/src/double.jl
+++ b/src/double.jl
@@ -1,18 +1,27 @@
 import Base: -, <, copysign, flipsign, convert
 
-struct Double{T<:IEEEFloat} <: Number
+const vIEEEFloat = Union{IEEEFloat,Vec{<:Any,<:IEEEFloat}}
+
+struct Double{T<:vIEEEFloat} <: Number
     hi::T
     lo::T
 end
-Double(x::T) where {T<:IEEEFloat} = Double(x, zero(T))
+Double(x::T) where {T<:vIEEEFloat} = Double(x, zero(T))
 
-(::Type{T})(x::Double{T}) where {T<:IEEEFloat} = x.hi + x.lo
+(::Type{T})(x::Double{T}) where {T<:vIEEEFloat} = x.hi + x.lo
 
 
 @inline trunclo(x::Float64) = reinterpret(Float64, reinterpret(UInt64, x) & 0xffff_ffff_f800_0000) # clear lower 27 bits (leave upper 26 bits)
 @inline trunclo(x::Float32) = reinterpret(Float32, reinterpret(UInt32, x) & 0xffff_f000) # clear lowest 12 bits (leave upper 12 bits)
 
-@inline function splitprec(x::IEEEFloat)
+@inline function trunclo(x::Vec{N,Float64}) where N
+    reinterpret(Vec{N,Float64}, reinterpret(Vec{N,UInt64}, x) & 0xffff_ffff_f800_0000) # clear lower 27 bits (leave upper 26 bits)
+end
+@inline function trunclo(x::Vec{N,Float32}) where N
+    reinterpret(Vec{N,Float32}, reinterpret(Vec{N,UInt32}, x) & 0xffff_f000) # clear lowest 12 bits (leave upper 12 bits)
+end
+
+@inline function splitprec(x::vIEEEFloat)
     hx = trunclo(x)
     hx, x - hx
 end
@@ -22,171 +31,175 @@ end
     Double(r, (x.hi - r) + x.lo)
 end
 
-@inline flipsign(x::Double{T}, y::T) where {T<:IEEEFloat} = Double(flipsign(x.hi, y), flipsign(x.lo, y))
+@inline flipsign(x::Double{<:vIEEEFloat}, y::vIEEEFloat) = Double(flipsign(x.hi, y), flipsign(x.lo, y))
 
-@inline scale(x::Double{T}, s::T) where {T<:IEEEFloat} = Double(s * x.hi, s * x.lo)
+@inline scale(x::Double{<:vIEEEFloat}, s::vIEEEFloat) = Double(s * x.hi, s * x.lo)
 
 
-@inline (-)(x::Double{T}) where {T<:IEEEFloat} = Double(-x.hi, -x.lo)
+@inline (-)(x::Double{T}) where {T<:vIEEEFloat} = Double(-x.hi, -x.lo)
 
-@inline function (<)(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+@inline function (<)(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
     x.hi < y.hi
 end
 
-@inline function (<)(x::Double{T}, y::Number) where {T<:IEEEFloat}
+@inline function (<)(x::Double{<:vIEEEFloat}, y::Union{Number,Vec})
     x.hi < y
 end
 
-@inline function (<)(x::Number, y::Double{T}) where {T<:IEEEFloat}
+@inline function (<)(x::Union{Number,Vec}, y::Double{<:vIEEEFloat})
     x < y.hi
 end
 
 # quick-two-sum x+y
-@inline function dadd(x::T, y::T) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dadd(x::vIEEEFloat, y::vIEEEFloat) #WARNING |x| >= |y|
     s = x + y
     Double(s, (x - s) + y)
 end
 
-@inline function dadd(x::T, y::Double{T}) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dadd(x::vIEEEFloat, y::Double{<:vIEEEFloat}) #WARNING |x| >= |y|
     s = x + y.hi
     Double(s, (x - s) + y.hi + y.lo)
 end
 
-@inline function dadd(x::Double{T}, y::T) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dadd(x::Double{<:vIEEEFloat}, y::vIEEEFloat) #WARNING |x| >= |y|
     s = x.hi + y
     Double(s, (x.hi - s) + y + x.lo)
 end
 
-@inline function dadd(x::Double{T}, y::Double{T}) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dadd(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}) #WARNING |x| >= |y|
     s = x.hi + y.hi
     Double(s, (x.hi - s) + y.hi + y.lo + x.lo)
 end
 
-@inline function dsub(x::Double{T}, y::Double{T}) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dsub(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}) #WARNING |x| >= |y|
     s = x.hi - y.hi
     Double(s, (x.hi - s) - y.hi - y.lo + x.lo)
 end
 
-@inline function dsub(x::Double{T}, y::T) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dsub(x::Double{<:vIEEEFloat}, y::vIEEEFloat) #WARNING |x| >= |y|
     s = x.hi - y
     Double(s, (x.hi - s) - y + x.lo)
 end
 
-@inline function dsub(x::T, y::Double{T}) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dsub(x::vIEEEFloat, y::Double{<:vIEEEFloat}) #WARNING |x| >= |y|
     s = x - y.hi
     Double(s, (x - s) - y.hi - y.lo)
 end
 
-@inline function dsub(x::T, y::T) where {T<:IEEEFloat} #WARNING |x| >= |y|
+@inline function dsub(x::vIEEEFloat, y::vIEEEFloat) #WARNING |x| >= |y|
     s = x - y
     Double(s, (x - s) - y)
 end
 
 
 # two-sum x+y  NO BRANCH
-@inline function dadd2(x::T, y::T) where {T<:IEEEFloat}
+@inline function dadd2(x::vIEEEFloat, y::vIEEEFloat)
     s = x + y
     v = s - x
     Double(s, (x - (s - v)) + (y - v))
 end
 
-@inline function dadd2(x::T, y::Double{T}) where {T<:IEEEFloat}
+@inline function dadd2(x::vIEEEFloat, y::Double{<:vIEEEFloat})
     s = x + y.hi
     v = s - x
     Double(s, (x - (s - v)) + (y.hi - v) + y.lo)
 end
 
-@inline dadd2(x::Double{T}, y::T) where {T<:IEEEFloat} = dadd2(y, x)
+@inline dadd2(x::Double{<:vIEEEFloat}, y::vIEEEFloat) = dadd2(y, x)
 
-@inline function dadd2(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+@inline function dadd2(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}) where {T<:vIEEEFloat}
     s = x.hi + y.hi
     v = s - x.hi
     Double(s, (x.hi - (s - v)) + (y.hi - v) + x.lo + y.lo)
 end
 
-@inline function dsub2(x::T, y::T) where {T<:IEEEFloat}
+@inline function dsub2(x::vIEEEFloat, y::vIEEEFloat)
     s = x - y
     v = s - x
     Double(s, (x - (s - v)) + (-y - v))
 end
 
-@inline function dsub2(x::T, y::Double{T}) where {T<:IEEEFloat}
+@inline function dsub2(x::vIEEEFloat, y::Double{<:vIEEEFloat})
     s = x - y.hi
     v = s - x
     Double(s, (x - (s - v)) + (-y.hi - v) - y.lo)
 end
 
-@inline function dsub2(x::Double{T}, y::T) where {T<:IEEEFloat}
+@inline function dsub2(x::Double{<:vIEEEFloat}, y::vIEEEFloat)
     s = x.hi - y
     v = s - x.hi
     Double(s, (x.hi - (s - v)) + (-y - v) + x.lo)
 end
 
-@inline function dsub2(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+@inline function dsub2(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
     s = x.hi - y.hi
     v = s - x.hi
     Double(s, (x.hi - (s - v)) + (-y.hi - v) + x.lo - y.lo)
 end
 
-
+@inline (::Type{Vec{N,T}})(x::Vec{N,T}) where {N,T} = x
+@inline function SIMD.vifelse(b::Vec{N,Bool}, x::Double{T1}, y::Double{T2}) where {N,T<:Union{Float32,Float64},T1<:Union{T,Vec{N,T}},T2<:Union{T,Vec{N,T}}}
+    V = Vec{N,T}
+    Double(vifelse(b, V(x.hi), V(y.hi)), vifelse(b, V(x.lo), V(y.lo)))
+end
 
 if FMA_FAST
 
     # two-prod-fma
-    @inline function dmul(x::T, y::T) where {T<:IEEEFloat}
+    @inline function dmul(x::vIEEEFloat, y::vIEEEFloat)
         z = x * y
         Double(z, fma(x, y, -z))
     end
 
-    @inline function dmul(x::Double{T}, y::T) where {T<:IEEEFloat}
+    @inline function dmul(x::Double{<:vIEEEFloat}, y::vIEEEFloat)
         z = x.hi * y
         Double(z, fma(x.hi, y, -z) + x.lo * y)
     end
 
-    @inline dmul(x::T, y::Double{T}) where {T<:IEEEFloat} = dmul(y, x)
+    @inline dmul(x::vIEEEFloat, y::Double{<:vIEEEFloat}) = dmul(y, x)
 
-    @inline function dmul(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+    @inline function dmul(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
         z = x.hi * y.hi
         Double(z, fma(x.hi, y.hi, -z) + x.hi * y.lo + x.lo * y.hi)
     end
 
     # x^2
-    @inline function dsqu(x::T) where {T<:IEEEFloat}
+    @inline function dsqu(x::T) where {T<:vIEEEFloat}
         z = x * x
         Double(z, fma(x, x, -z))
     end
 
-    @inline function dsqu(x::Double{T}) where {T<:IEEEFloat}
+    @inline function dsqu(x::Double{T}) where {T<:vIEEEFloat}
         z = x.hi * x.hi
         Double(z, fma(x.hi, x.hi, -z) + x.hi * (x.lo + x.lo))
     end
 
     # sqrt(x)
-    @inline function dsqrt(x::Double{T}) where {T<:IEEEFloat}
+    @inline function dsqrt(x::Double{T}) where {T<:vIEEEFloat}
         zhi = _sqrt(x.hi)
         Double(zhi, (x.lo + fma(-zhi, zhi, x.hi)) / (zhi + zhi))
     end
 
     # x/y
-    @inline function ddiv(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+    @inline function ddiv(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
         invy = 1 / y.hi
         zhi = x.hi * invy
         Double(zhi, (fma(-zhi, y.hi, x.hi) + fma(-zhi, y.lo, x.lo)) * invy)
     end
 
-    @inline function ddiv(x::T, y::T) where {T<:IEEEFloat}
+    @inline function ddiv(x::vIEEEFloat, y::vIEEEFloat)
         ry = 1 / y
         r = x * ry
         Double(r, fma(-r, y, x) * ry)
     end
 
     # 1/x
-    @inline function drec(x::T) where {T<:IEEEFloat}
+    @inline function drec(x::vIEEEFloat)
         zhi = 1 / x
         Double(zhi, fma(-zhi, x, one(T)) * zhi)
     end
 
-    @inline function drec(x::Double{T}) where {T<:IEEEFloat}
+    @inline function drec(x::Double{<:vIEEEFloat})
         zhi = 1 / x.hi
         Double(zhi, (fma(-zhi, x.hi, one(T)) + -zhi * x.lo) * zhi)
     end
@@ -194,23 +207,23 @@ if FMA_FAST
 else
 
     #two-prod x*y
-    @inline function dmul(x::T, y::T) where {T<:IEEEFloat}
+    @inline function dmul(x::vIEEEFloat, y::vIEEEFloat)
         hx, lx = splitprec(x)
         hy, ly = splitprec(y)
         z = x * y
         Double(z, ((hx * hy - z) + lx * hy + hx * ly) + lx * ly)
     end
 
-    @inline function dmul(x::Double{T}, y::T) where {T<:IEEEFloat}
+    @inline function dmul(x::Double{<:vIEEEFloat}, y::vIEEEFloat)
         hx, lx = splitprec(x.hi)
         hy, ly = splitprec(y)
         z = x.hi * y
         Double(z, (hx * hy - z) + lx * hy + hx * ly + lx * ly + x.lo * y)
     end
 
-    @inline dmul(x::T, y::Double{T}) where {T<:IEEEFloat} = dmul(y, x)
+    @inline dmul(x::vIEEEFloat, y::Double{<:vIEEEFloat}) = dmul(y, x)
 
-    @inline function dmul(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+    @inline function dmul(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
         hx, lx = splitprec(x.hi)
         hy, ly = splitprec(y.hi)
         z = x.hi * y.hi
@@ -218,34 +231,34 @@ else
     end
 
     # x^2
-    @inline function dsqu(x::T) where {T<:IEEEFloat}
+    @inline function dsqu(x::T) where {T<:vIEEEFloat}
         hx, lx = splitprec(x)
         z = x * x
         Double(z, (hx * hx - z) + lx * (hx + hx) + lx * lx)
     end
 
-    @inline function dsqu(x::Double{T}) where {T<:IEEEFloat}
+    @inline function dsqu(x::Double{T}) where {T<:vIEEEFloat}
         hx, lx = splitprec(x.hi)
         z = x.hi * x.hi
         Double(z, (hx * hx - z) + lx * (hx + hx) + lx * lx + x.hi * (x.lo + x.lo))
     end
 
     # sqrt(x)
-    @inline function dsqrt(x::Double{T}) where {T<:IEEEFloat}
+    @inline function dsqrt(x::Double{T}) where {T<:vIEEEFloat}
         c = _sqrt(x.hi)
         u = dsqu(c)
         Double(c, (x.hi - u.hi - u.lo + x.lo) / (c + c))
     end
 
     # x/y
-    @inline function ddiv(x::Double{T}, y::Double{T}) where {T<:IEEEFloat}
+    @inline function ddiv(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat})
         invy = 1 / y.hi
         c = x.hi * invy
         u = dmul(c, y.hi)
         Double(c, ((((x.hi - u.hi) - u.lo) + x.lo) - c * y.lo) * invy)
     end
 
-    @inline function ddiv(x::T, y::T) where {T<:IEEEFloat}
+    @inline function ddiv(x::vIEEEFloat, y::vIEEEFloat)
         ry = 1 / y
         r = x * ry
         hx, lx = splitprec(r)
@@ -255,13 +268,13 @@ else
 
 
     # 1/x
-    @inline function drec(x::T) where {T<:IEEEFloat}
+    @inline function drec(x::T) where {T<:vIEEEFloat}
         c = 1 / x
         u = dmul(c, x)
         Double(c, (one(T) - u.hi - u.lo) * c)
     end
 
-    @inline function drec(x::Double{T}) where {T<:IEEEFloat}
+    @inline function drec(x::Double{T}) where {T<:vIEEEFloat}
         c = 1 / x.hi
         u = dmul(c, x.hi)
         Double(c, (one(T) - u.hi - u.lo - c * x.lo) * c)

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -5,7 +5,7 @@
 
 Computes `a × 2^n`
 """
-ldexp(x::Union{Float32,Float64}, q::Int) = ldexpk(x, q)
+ldexp(x::FloatType, q::IntegerType) = ldexpk(x, q)
 
 
 const max_exp2(::Type{Float64}) = 1024
@@ -14,7 +14,7 @@ const max_exp2(::Type{Float32}) = 128f0
 const min_exp2(::Type{Float64}) = -1075
 const min_exp2(::Type{Float32}) = -150f0
 
-@inline function exp2_kernel(x::Float64)
+@inline function exp2_kernel(x::FloatType64)
     c11 = 0.4434359082926529454e-9
     c10 = 0.7073164598085707425e-8
     c9  = 0.1017819260921760451e-6
@@ -26,17 +26,17 @@ const min_exp2(::Type{Float32}) = -150f0
     c3  = 0.5550410866482046596e-1
     c2  = 0.2402265069591012214
     c1  = 0.6931471805599452862
-    return @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11
+    @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11
 end
 
-@inline function exp2_kernel(x::Float32)
+@inline function exp2_kernel(x::FloatType32)
     c6 = 0.1535920892f-3
     c5 = 0.1339262701f-2
     c4 = 0.9618384764f-2
     c3 = 0.5550347269f-1
     c2 = 0.2402264476f0
     c1 = 0.6931471825f0
-    return @horner x c1 c2 c3 c4 c5 c6
+    @horner x c1 c2 c3 c4 c5 c6
 end
 
 """
@@ -44,30 +44,31 @@ end
 
 Compute the base-`2` exponential of `x`, that is `2ˣ`.
 """
-function exp2(d::T) where {T<:Union{Float32,Float64}}
+function exp2(d::V) where V <: FloatType
+    T = eltype(d)
     q = round(d)
-    qi = unsafe_trunc(Int, q)
+    qi = unsafe_trunc(EquivalentInteger(T), q)
 
     s = d - q
 
     u = exp2_kernel(s)
-    u = T(dnormalize(dadd(T(1.0), dmul(u,s))))
+    u = V(dnormalize(dadd(T(1.0), dmul(u,s))))
 
     u = ldexp2k(u, qi)
 
-    d > max_exp2(T) && (u = T(Inf))
-    d < min_exp2(T) && (u = T(0.0))
-    return u
+    u = vifelse(d > max_exp2(T), T(Inf), u)
+    u = vifelse(d < min_exp2(T), T(0.0), u)
+    u
 end
 
 
-const max_exp10(::Type{Float64}) = 3.08254715559916743851e2 # log 2^1023*(2-2^-52)
-const max_exp10(::Type{Float32}) = 38.531839419103626f0 # log 2^127 *(2-2^-23) 
+const max_exp10(::Type{<:FloatType64}) = 3.08254715559916743851e2 # log 2^1023*(2-2^-52)
+const max_exp10(::Type{<:FloatType32}) = 38.531839419103626f0 # log 2^127 *(2-2^-23)
 
-const min_exp10(::Type{Float64}) = -3.23607245338779784854769e2 # log10 2^-1075
-const min_exp10(::Type{Float32}) = -45.15449934959718f0         # log10 2^-150
+const min_exp10(::Type{<:FloatType64}) = -3.23607245338779784854769e2 # log10 2^-1075
+const min_exp10(::Type{<:FloatType32}) = -45.15449934959718f0         # log10 2^-150
 
-@inline function exp10_kernel(x::Float64)
+@inline function exp10_kernel(x::FloatType64)
     c11 = 0.2411463498334267652e-3
     c10 = 0.1157488415217187375e-2
     c9  = 0.5013975546789733659e-2
@@ -82,7 +83,7 @@ const min_exp10(::Type{Float32}) = -45.15449934959718f0         # log10 2^-150
     return @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11
 end
 
-@inline function exp10_kernel(x::Float32)
+@inline function exp10_kernel(x::FloatType32)
     c6 = 0.2064004987f0
     c5 = 0.5417877436f0
     c4 = 0.1171286821f1
@@ -97,52 +98,54 @@ end
 
 Compute the base-`10` exponential of `x`, that is `10ˣ`.
 """
-function exp10(d::T) where {T<:Union{Float32,Float64}}
+function exp10(d::V) where V <: FloatType
+    T = eltype(d)
     q = round(T(MLOG10_2) * d)
-    qi = unsafe_trunc(Int, q)
+    qi = unsafe_trunc(EquivalentInteger(T), q)
 
     s = muladd(q, -L10U(T), d)
     s = muladd(q, -L10L(T), s)
 
     u = exp10_kernel(s)
-    u = T(dnormalize(dadd(T(1.0), dmul(u,s))))
+    u = V(dnormalize(dadd(T(1.0), dmul(u,s))))
 
     u = ldexp2k(u, qi)
 
-    d > max_exp10(T) && (u = T(Inf))
-    d < min_exp10(T) && (u = T(0.0))
+    u = vifelse(d > max_exp10(T), T(Inf), u)
+    u = vifelse(d < min_exp10(T), T(0.0), u)
 
-    return u
+    u
 end
 
 
-const max_expm1(::Type{Float64}) = 7.09782712893383996732e2 # log 2^1023*(2-2^-52)
-const max_expm1(::Type{Float32}) = 88.72283905206835f0 # log 2^127 *(2-2^-23)
+const max_expm1(::Type{<:FloatType64}) = 7.09782712893383996732e2 # log 2^1023*(2-2^-52)
+const max_expm1(::Type{<:FloatType32}) = 88.72283905206835f0 # log 2^127 *(2-2^-23)
 
-const min_expm1(::Type{Float64}) = -37.42994775023704434602223
-const min_expm1(::Type{Float32}) = -17.3286790847778338076068394f0
+const min_expm1(::Type{<:FloatType64}) = -37.42994775023704434602223
+const min_expm1(::Type{<:FloatType32}) = -17.3286790847778338076068394f0
 
 """
     expm1(x)
 
 Compute `eˣ- 1` accurately for small values of `x`.
 """
-function expm1(x::T) where {T<:Union{Float32,Float64}}
+function expm1(x::FloatType)
+    T = eltype(x)
     u = T(dadd2(expk2(Double(x)), -T(1.0)))
-    x > max_expm1(T) && (u = T(Inf))
-    x < min_expm1(T) && (u = -T(1.0))
-    isnegzero(x) && (u = T(-0.0))
+    u = vifelse(x > max_expm1(T), T(Inf), u)
+    u = vifelse(x < min_expm1(T), T(-1.0), u)
+    u = vifelse(isnegzero(x), T(-0.0), u)
     return u
 end
 
 
-const max_exp(::Type{Float64}) = 709.78271114955742909217217426  # log 2^1023*(2-2^-52)
-const max_exp(::Type{Float32}) = 88.72283905206835f0             # log 2^127 *(2-2^-23)
+const max_exp(::Type{<:FloatType64}) = 709.78271114955742909217217426  # log 2^1023*(2-2^-52)
+const max_exp(::Type{<:FloatType32}) = 88.72283905206835f0             # log 2^127 *(2-2^-23)
 
-const min_exp(::Type{Float64}) = -7.451332191019412076235e2 # log 2^-1075
-const min_exp(::Type{Float32}) = -103.97208f0               # ≈ log 2^-150
+const min_exp(::Type{<:FloatType64}) = -7.451332191019412076235e2 # log 2^-1075
+const min_exp(::Type{<:FloatType32}) = -103.97208f0               # ≈ log 2^-150
 
-@inline function exp_kernel(x::Float64)
+@inline function exp_kernel(x::FloatType64)
     c11 = 2.08860621107283687536341e-09
     c10 = 2.51112930892876518610661e-08
     c9  = 2.75573911234900471893338e-07
@@ -154,17 +157,17 @@ const min_exp(::Type{Float32}) = -103.97208f0               # ≈ log 2^-150
     c3  = 0.0416666666666665047591422
     c2  = 0.166666666666666851703837
     c1  = 0.50
-    return @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11
+    @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11
 end
 
-@inline function exp_kernel(x::Float32)
+@inline function exp_kernel(x::FloatType32)
     c6 = 0.000198527617612853646278381f0
     c5 = 0.00139304355252534151077271f0
     c4 = 0.00833336077630519866943359f0
     c3 = 0.0416664853692054748535156f0
     c2 = 0.166666671633720397949219f0
     c1 = 0.5f0
-    return @horner x c1 c2 c3 c4 c5 c6
+    @horner x c1 c2 c3 c4 c5 c6
 end
 
 """
@@ -172,20 +175,20 @@ end
 
 Compute the base-`e` exponential of `x`, that is `eˣ`.
 """
-function exp(d::T) where {T<:Union{Float32,Float64}}
+function exp(d::FloatType)
+    T = eltype(d)
     q = round(T(MLN2E) * d)
-    qi = unsafe_trunc(Int, q)
+    qi = unsafe_trunc(EquivalentInteger(T), q)
 
     s = muladd(q, -L2U(T), d)
     s = muladd(q, -L2L(T), s)
 
     u = exp_kernel(s)
-
-    u = s * s * u + s + 1
+    u = muladd(s * s, u, s) + 1
     u = ldexp2k(u, qi)
 
-    d > max_exp(T) && (u = T(Inf))
-    d < min_exp(T) && (u = T(0))
+    u = vifelse(d > max_exp(T), T(Inf), u)
+    u = vifelse(d < min_exp(T), T(0), u)
 
-    return u
+    u
 end

--- a/src/hyp.jl
+++ b/src/hyp.jl
@@ -8,15 +8,16 @@ over_sch(::Type{Float32}) = 89f0
 
 Compute hyperbolic sine of `x`.
 """
-function sinh(x::T) where {T<:Union{Float32,Float64}}
+function sinh(x::FloatType)
+    T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     d = dsub(d, drec(d))
     u = T(d) * T(0.5)
-    u = abs(x) > over_sch(T) ? T(Inf) : u
-    u = isnan(u) ? T(Inf) : u
+    u = vifelse(abs(x) > over_sch(T), T(Inf), u)
+    u = vifelse(isnan(u), T(Inf), u)
     u = flipsign(u, x)
-    u = isnan(x) ? T(NaN) : u
+    u = vifelse(isnan(x), T(NaN), u)
     return u
 end
 
@@ -27,14 +28,15 @@ end
 
 Compute hyperbolic cosine of `x`.
 """
-function cosh(x::T) where {T<:Union{Float32,Float64}}
+function cosh(x::FloatType)
+    T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     d = dadd(d, drec(d))
     u = T(d) * T(0.5)
-    u = abs(x) > over_sch(T) ? T(Inf) : u
-    u = isnan(u) ? T(Inf) : u
-    u = isnan(x) ? T(NaN) : u
+    u = vifelse(abs(x) > over_sch(T), T(Inf), u)
+    u = vifelse(isnan(u), T(Inf), u)
+    u = vifelse(isnan(x), T(NaN), u)
     return u
 end
 
@@ -48,16 +50,17 @@ over_th(::Type{Float32}) = 18.714973875f0
 
 Compute hyperbolic tangent of `x`.
 """
-function tanh(x::T) where {T<:Union{Float32,Float64}}
+function tanh(x::FloatType)
+    T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     e = drec(d)
     d = ddiv(dsub(d, e), dadd(d, e))
     u = T(d)
-    u = abs(x) > over_th(T) ? T(1.0) : u
-    u = isnan(u) ? T(1) : u
+    u = vifelse(abs(x) > over_th(T), T(1.0), u)
+    u = vifelse(isnan(u), T(1), u)
     u = flipsign(u, x)
-    u = isnan(x) ? T(NaN) : u
+    u = vifelse(isnan(x), T(NaN), u)
     return u
 end
 
@@ -68,20 +71,22 @@ end
 
 Compute the inverse hyperbolic sine of `x`.
 """
-function asinh(x::T) where {T<:Union{Float32,Float64}}
+function asinh(x::V) where V <: FloatType
+    T = eltype(x)
     y = abs(x)
 
-    d = y > 1 ? drec(x) : Double(y, T(0.0))
+    yg1 = y > 1
+    d = vifelse(yg1, drec(x), Double(y, V(0.0)))
     d = dsqrt(dadd2(dsqu(d), T(1.0)))
-    d = y > 1 ? dmul(d, y) : d
+    d = vifelse(yg1, dmul(d, y), d)
 
     d = logk2(dnormalize(dadd(d, x)))
     y = T(d)
 
-    y = (abs(x) > SQRT_MAX(T) || isnan(y)) ? flipsign(T(Inf), x) : y
-    y = isnan(x) ? T(NaN) : y
-    y = isnegzero(x) ? T(-0.0) : y
-    
+    y = vifelse(((abs(x) > SQRT_MAX(T)) | isnan(y)), flipsign(T(Inf), x), y)
+    y = vifelse(isnan(x), T(NaN), y)
+    y = vifelse(isnegzero(x), T(-0.0), y)
+
     return y
 end
 
@@ -92,14 +97,15 @@ end
 
 Compute the inverse hyperbolic cosine of `x`.
 """
-function acosh(x::T) where {T<:Union{Float32,Float64}}
+function acosh(x::FloatType)
+    T = eltype(x)
     d = logk2(dadd2(dmul(dsqrt(dadd2(x, T(1.0))), dsqrt(dsub2(x, T(1.0)))), x))
     y = T(d)
 
-    y = (x > SQRT_MAX(T) || isnan(y)) ? T(Inf) : y
-    y = x == T(1.0) ? T(0.0) : y
-    y = x < T(1.0) ? T(NaN) : y
-    y = isnan(x) ? T(NaN) : y
+    y = vifelse(((x > SQRT_MAX(T)) | isnan(y)), T(Inf), y)
+    y = vifelse(x == T(1.0), T(0.0), y)
+    y = vifelse(x < T(1.0), T(NaN), y)
+    y = vifelse(isnan(x), T(NaN), y)
 
     return y
 end
@@ -111,14 +117,15 @@ end
 
 Compute the inverse hyperbolic tangent of `x`.
 """
-function atanh(x::T) where {T<:Union{Float32,Float64}}
+function atanh(x::FloatType)
+    T = eltype(x)
     u = abs(x)
     d = logk2(ddiv(dadd2(T(1.0), u), dsub2(T(1.0), u)))
-    u = u > T(1.0) ? T(NaN) : (u == T(1.0) ? T(Inf) : T(d) * T(0.5))
+    u = vifelse(u > T(1.0), T(NaN), vifelse(u == T(1.0), T(Inf), T(d) * T(0.5)))
 
-    u = isinf(x) || isnan(u) ? T(NaN) : u
+    u = vifelse(isinf(x) | isnan(u), T(NaN), u)
     u = flipsign(u, x)
-    u = isnan(x) ? T(NaN) : u
+    u = vifelse(isnan(x), T(NaN), u)
 
     return u
 end

--- a/src/hyp.jl
+++ b/src/hyp.jl
@@ -8,12 +8,12 @@ over_sch(::Type{Float32}) = 89f0
 
 Compute hyperbolic sine of `x`.
 """
-function sinh(x::FloatType)
+function sinh(x::V) where V <: FloatType
     T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     d = dsub(d, drec(d))
-    u = T(d) * T(0.5)
+    u = V(d) * T(0.5)
     u = vifelse(abs(x) > over_sch(T), T(Inf), u)
     u = vifelse(isnan(u), T(Inf), u)
     u = flipsign(u, x)
@@ -28,12 +28,12 @@ end
 
 Compute hyperbolic cosine of `x`.
 """
-function cosh(x::FloatType)
+function cosh(x::V) where V <: FloatType
     T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     d = dadd(d, drec(d))
-    u = T(d) * T(0.5)
+    u = V(d) * T(0.5)
     u = vifelse(abs(x) > over_sch(T), T(Inf), u)
     u = vifelse(isnan(u), T(Inf), u)
     u = vifelse(isnan(x), T(NaN), u)
@@ -50,13 +50,13 @@ over_th(::Type{Float32}) = 18.714973875f0
 
 Compute hyperbolic tangent of `x`.
 """
-function tanh(x::FloatType)
+function tanh(x::V) where V <: FloatType
     T = eltype(x)
     u = abs(x)
     d = expk2(Double(u))
     e = drec(d)
     d = ddiv(dsub(d, e), dadd(d, e))
-    u = T(d)
+    u = V(d)
     u = vifelse(abs(x) > over_th(T), T(1.0), u)
     u = vifelse(isnan(u), T(1), u)
     u = flipsign(u, x)
@@ -81,7 +81,7 @@ function asinh(x::V) where V <: FloatType
     d = vifelse(yg1, dmul(d, y), d)
 
     d = logk2(dnormalize(dadd(d, x)))
-    y = T(d)
+    y = V(d)
 
     y = vifelse(((abs(x) > SQRT_MAX(T)) | isnan(y)), flipsign(T(Inf), x), y)
     y = vifelse(isnan(x), T(NaN), y)
@@ -97,10 +97,10 @@ end
 
 Compute the inverse hyperbolic cosine of `x`.
 """
-function acosh(x::FloatType)
+function acosh(x::V) where V <: FloatType
     T = eltype(x)
     d = logk2(dadd2(dmul(dsqrt(dadd2(x, T(1.0))), dsqrt(dsub2(x, T(1.0)))), x))
-    y = T(d)
+    y = V(d)
 
     y = vifelse(((x > SQRT_MAX(T)) | isnan(y)), T(Inf), y)
     y = vifelse(x == T(1.0), T(0.0), y)
@@ -117,11 +117,11 @@ end
 
 Compute the inverse hyperbolic tangent of `x`.
 """
-function atanh(x::FloatType)
+function atanh(x::V) where V <: FloatType
     T = eltype(x)
     u = abs(x)
     d = logk2(ddiv(dadd2(T(1.0), u), dsub2(T(1.0), u)))
-    u = vifelse(u > T(1.0), T(NaN), vifelse(u == T(1.0), T(Inf), T(d) * T(0.5)))
+    u = vifelse(u > T(1.0), T(NaN), vifelse(u == T(1.0), T(Inf), V(d) * T(0.5)))
 
     u = vifelse(isinf(x) | isnan(u), T(NaN), u)
     u = flipsign(u, x)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -4,68 +4,71 @@
 
 Exponentiation operator, returns `x` raised to the power `y`.
 """
-function pow(x::T, y::T) where {T<:Union{Float32,Float64}}
-    yi = unsafe_trunc(Int, y)
+function pow(x::V, y::V) where {V <: FloatType}
+    T = eltype(x)
+    yi = unsafe_trunc(EquivalentInteger(T), y)
     yisint = yi == y
-    yisodd = isodd(yi) && yisint
-    
+    yisodd = isodd(yi) & yisint
+
     result = expk(dmul(logk(abs(x)), y))
 
-    result = isnan(result) ? T(Inf) : result
-    result *= (x > 0 ? T(1.0) : (!yisint ? T(NaN) : (yisodd ? -T(1.0) : T(1.0))))
+    result = vifelse(isnan(result), T(Inf), result)
+    result = vifelse(x > 0, result, vifelse(!yisint, T(NaN), vifelse(yisodd, -result, result)))
 
     efx = flipsign(abs(x) - 1, y)
-    isinf(y) && (result = efx < 0 ? T(0.0) : (efx == 0 ? T(1.0) : T(Inf)))
-    (isinf(x) || x == 0) && (result = (yisodd ? _sign(x) : T(1.0)) * ((x == 0 ? -y : y) < 0 ? T(0.0) : T(Inf)))
-    (isnan(x) || isnan(y)) && (result = T(NaN))
-    (y == 0 || x == 1) && (result = T(1.0))
+    result = vifelse(isinf(y), vifelse(efx < 0, T(0.0), vifelse(efx == 0, T(1.0), T(Inf))), result)
+    result = vifelse(isinf(x) | (x == 0), vifelse(yisodd, _sign(x), T(1.0)) * vifelse(vifelse(x == 0, -y, y) < 0, T(0.0), T(Inf)), result)
+    result = vifelse(isnan(x) | isnan(y), T(NaN), result)
+    result = vifelse((y == 0) | (x == 1), T(1.0), result)
 
     return result
 end
 
 
 
-let
-global cbrt_fast
-global cbrt
 
-c6d = -0.640245898480692909870982
-c5d = 2.96155103020039511818595
-c4d = -5.73353060922947843636166
-c3d = 6.03990368989458747961407
-c2d = -3.85841935510444988821632
-c1d = 2.2307275302496609725722
 
-c6f = -0.601564466953277587890625f0
-c5f =  2.8208892345428466796875f0
-c4f = -5.532182216644287109375f0
-c3f =  5.898262500762939453125f0
-c2f = -3.8095417022705078125f0
-c1f =  2.2241256237030029296875f0
 
-global @inline cbrt_kernel(x::Float64) = @horner x c1d c2d c3d c4d c5d c6d
-global @inline cbrt_kernel(x::Float32) = @horner x c1f c2f c3f c4f c5f c6f
+@inline function cbrt_kernel(x::FloatType64)
+    c6d = -0.640245898480692909870982
+    c5d = 2.96155103020039511818595
+    c4d = -5.73353060922947843636166
+    c3d = 6.03990368989458747961407
+    c2d = -3.85841935510444988821632
+    c1d = 2.2307275302496609725722
+    @horner x c1d c2d c3d c4d c5d c6d
+end
+@inline function cbrt_kernel(x::FloatType32)
+    c6f = -0.601564466953277587890625f0
+    c5f =  2.8208892345428466796875f0
+    c4f = -5.532182216644287109375f0
+    c3f =  5.898262500762939453125f0
+    c2f = -3.8095417022705078125f0
+    c1f =  2.2241256237030029296875f0
+    @horner x c1f c2f c3f c4f c5f c6f
+end
 
 """
     cbrt_fast(x)
 
 Return `x^{1/3}`.
 """
-function cbrt_fast(d::T) where {T<:Union{Float32,Float64}}
+function cbrt_fast(d::V) where V <: FloatType
+    T  = eltype(d)
     e  = ilogbk(abs(d)) + 1
     d  = ldexp2k(d, -e)
     r  = (e + 6144) % 3
-    q  = r == 1 ? T(M2P13) : T(1)
-    q  = r == 2 ? T(M2P23) : q
+    q  = vifelse(r == 1, V(M2P13), V(1))
+    q  = vifelse(r == 2, V(M2P23), q)
     q  = ldexp2k(q, (e + 6144) ÷ 3 - 2048)
     q  = flipsign(q, d)
     d  = abs(d)
     x  = cbrt_kernel(d)
     y  = x * x
     y  = y * y
-    x -= (d * y - x) * T(1 / 3)
+    x  = muladd(T(-1/3), muladd(d, y, - x), x)
     y  = d * x * x
-    y  = (y - T(2 / 3) * y * (y * x - 1)) * q
+    y  = (y - T(2 / 3) * y * muladd(y, x, T(- 1))) * q
 end
 
 
@@ -74,33 +77,33 @@ end
 
 Return `x^{1/3}`. The prefix operator `∛` is equivalent to `cbrt`.
 """
-function cbrt(d::T) where {T<:Union{Float32,Float64}}
+function cbrt(d::V) where V <: FloatType
+    T  = eltype(d)
     e  = ilogbk(abs(d)) + 1
     d  = ldexp2k(d, -e)
     r  = (e + 6144) % 3
-    q2 = r == 1 ? MD2P13(T) : Double(T(1))
-    q2 = r == 2 ? MD2P23(T) : q2
+    q2 = vifelse(r == 1, MD2P13(T), Double(T(1)))
+    q2 = vifelse(r == 2, MD2P23(T), q2)
     q2 = flipsign(q2, d)
     d  = abs(d)
     x  = cbrt_kernel(d)
     y  = x * x
     y  = y * y
-    x -= (d * y - x) * T(1 / 3)
+    x  = muladd(T(-1 / 3), muladd(d, y, - x), x)
     z  = x
     u  = dsqu(x)
     u  = dsqu(u)
     u  = dmul(u, d)
     u  = dsub(u, x)
-    y  = T(u)
-    y  = -T(2 / 3) * y * z
+    y  = V(u)
+    y  = T(-2 / 3) * y * z
     v  = dadd(dsqu(z), y)
     v  = dmul(v, d)
     v  = dmul(v, q2)
-    z  = ldexp2k(T(v), (e + 6144) ÷ 3 - 2048)
-    isinf(d) && (z = flipsign(T(Inf), q2.hi))
-    d == 0   && (z = flipsign(T(0), q2.hi))
+    z  = ldexp2k(V(v), (e + 6144) ÷ 3 - 2048)
+    z  = vifelse(isinf(d), flipsign(T(Inf), q2.hi), z)
+    z  = vifelse(d == 0, flipsign(T(0), q2.hi), z)
     return z
-end
 end
 
 
@@ -110,12 +113,13 @@ end
 
 Compute the hypotenuse `\\sqrt{x^2+y^2}` avoiding overflow and underflow.
 """
-function hypot(x::T, y::T) where {T<:IEEEFloat}
-    x = abs(x)
-    y = abs(y)
-    if x < y
-       x, y = y, x
-    end
-    r = (x == 0) ? y : y / x
-    x * sqrt(T(1.0) + r * r)
+function hypot(x::T, y::T) where {T<:vIEEEFloat}
+    a = abs(x)
+    b = abs(y)
+
+    x = min(a,b)
+    y = max(a,b)
+
+    r = vifelse(x == 0, y, y / x)
+    x * _sqrt(muladd(r, r, T(1.0)))
 end

--- a/src/priv.jl
+++ b/src/priv.jl
@@ -23,39 +23,50 @@ exponent amount back in.
     q = q - (m << offset)
     m, q
 end
-@inline split_exponent(::Type{Float64}, q::Int) = _split_exponent(q, UInt(9), UInt(31), UInt(2))
-@inline split_exponent(::Type{Float32}, q::Int) = _split_exponent(q, UInt(6), UInt(31), UInt(2))
+@inline split_exponent(::Type{Float64}, q::IntegerType) = _split_exponent(q, UInt(9), UInt(31), UInt(2))
 
+@inline split_exponent(::Type{Float32}, q::IntegerType) = _split_exponent(q, UInt(6), UInt(31), UInt(2))
 """
     ldexpk(a, n)
 
 Computes `a × 2^n`.
 """
-@inline function ldexpk(x::T, q::Int) where {T<:Union{Float32,Float64}}
+@inline function ldexpk(x::FloatType, q::IntegerType)
+    T = eltype(x)
     bias = exponent_bias(T)
     emax = exponent_raw_max(T)
     m, q = split_exponent(T, q)
     m += bias
-    m = ifelse(m < 0, 0, m)
-    m = ifelse(m > emax, emax, m)
+    m = vifelse(m < 0, 0, m)
+    m = vifelse(m > emax, emax, m)
     q += bias
     u = integer2float(T, m)
-    x = x * u * u * u * u
+    u² = u * u
+    x = x * u² * u²
     u = integer2float(T, q)
     x * u
 end
 
-@inline function ldexp2k(x::T, e::Int) where {T<:Union{Float32,Float64}}
-    x * pow2i(T, e >> 1) * pow2i(T, e - (e >> 1))
+@inline function ldexp2k(x::FloatType, e::IntegerType)
+    x * pow2i(eltype(x), e >> 1) * pow2i(eltype(x), e - (e >> 1))
 end
 
 @inline function ldexp3k(x::T, e::Int) where {T<:Union{Float32,Float64}}
     reinterpret(T, reinterpret(Unsigned, x) + (Int64(e) << significand_bits(T)) % uinttype(T))
 end
+@generated function ldexp3k(x::Vec{N,T}, e::IntegerType) where {N,T<:Union{Float32,Float64}}
+    UT = Base.uinttype(T)
+    quote
+        $(Expr(:meta,:inline))
+        reinterpret(Vec{$N,$T}, reinterpret(Vec{$N,$UT}, x) +
+            Vec{$N,$UT}($(Expr(:tuple, [:((Int64(e[$n]) << $(significand_bits(T))) % $UT) for n ∈ 1:N]...)))
+        )
+    end
+end
 
 # threshold values for `ilogbk`
-const threshold_exponent(::Type{Float64}) = 300
-const threshold_exponent(::Type{Float32}) = 64
+threshold_exponent(::Type{Float64}) = 300
+threshold_exponent(::Type{Float32}) = 64
 
 """
     ilogbk(x) -> Int
@@ -67,90 +78,85 @@ words this returns the binary exponent of `x` so that
 
 where `significand ∈ [1, 2)`.
 """
-@inline function ilogbk(d::T) where {T<:Union{Float32,Float64}}
-    m = d < T(2)^-threshold_exponent(T)
-    d = ifelse(m, d * T(2)^threshold_exponent(T), d)
+@inline function ilogbk(d::FloatType)
+    T = eltype(d)
+    m = d < (T(2)^-threshold_exponent(T))
+    d = vifelse(m, d * T(2)^threshold_exponent(T), d)
     q = float2integer(d) & exponent_raw_max(T)
-    q = ifelse(m, q - (threshold_exponent(T) + exponent_bias(T)), q - exponent_bias(T))
+    q = vifelse(m, q - (threshold_exponent(T) + exponent_bias(T)), q - exponent_bias(T))
 end
 
 # similar to ilogbk, but argument has to be a normalized float value
-@inline function ilogb2k(d::T) where {T<:Union{Float32,Float64}}
-    (float2integer(d) & exponent_raw_max(T)) - exponent_bias(T)
+@inline function ilogb2k(d::FloatType)
+    T = eltype(d)
+    I = EquivalentInteger(T)
+    (float2integer(d) & I(exponent_raw_max(T))) - I(exponent_bias(T))
 end
 
+const c20d =  1.06298484191448746607415e-05
+const c19d = -0.000125620649967286867384336
+const c18d =  0.00070557664296393412389774
+const c17d = -0.00251865614498713360352999
+const c16d =  0.00646262899036991172313504
+const c15d = -0.0128281333663399031014274
+const c14d =  0.0208024799924145797902497
+const c13d = -0.0289002344784740315686289
+const c12d =  0.0359785005035104590853656
+const c11d = -0.041848579703592507506027
+const c10d =  0.0470843011653283988193763
+const c9d  = -0.0524914210588448421068719
+const c8d  =  0.0587946590969581003860434
+const c7d  = -0.0666620884778795497194182
+const c6d  =  0.0769225330296203768654095
+const c5d  = -0.0909090442773387574781907
+const c4d  =  0.111111108376896236538123
+const c3d  = -0.142857142756268568062339
+const c2d  =  0.199999999997977351284817
+const c1d =  -0.333333333333317605173818
 
-let
-global atan2k_fast
-global atan2k
+const c9f = -0.00176397908944636583328247f0
+const c8f =  0.0107900900766253471374512f0
+const c7f = -0.0309564601629972457885742f0
+const c6f =  0.0577365085482597351074219f0
+const c5f = -0.0838950723409652709960938f0
+const c4f =  0.109463557600975036621094f0
+const c3f = -0.142626821994781494140625f0
+const c2f =  0.199983194470405578613281f0
+const c1f = -0.333332866430282592773438f0
 
-c20d =  1.06298484191448746607415e-05
-c19d = -0.000125620649967286867384336
-c18d =  0.00070557664296393412389774
-c17d = -0.00251865614498713360352999
-c16d =  0.00646262899036991172313504
-c15d = -0.0128281333663399031014274
-c14d =  0.0208024799924145797902497
-c13d = -0.0289002344784740315686289
-c12d =  0.0359785005035104590853656
-c11d = -0.041848579703592507506027
-c10d =  0.0470843011653283988193763
-c9d  = -0.0524914210588448421068719
-c8d  =  0.0587946590969581003860434
-c7d  = -0.0666620884778795497194182
-c6d  =  0.0769225330296203768654095
-c5d  = -0.0909090442773387574781907
-c4d  =  0.111111108376896236538123
-c3d  = -0.142857142756268568062339
-c2d  =  0.199999999997977351284817
-c1d =  -0.333333333333317605173818
+@inline atan2k_fast_kernel(x::FloatType64) = @horner x c1d c2d c3d c4d c5d c6d c7d c8d c9d c10d c11d c12d c13d c14d c15d c16d c17d c18d c19d c20d
+@inline atan2k_fast_kernel(x::FloatType32) = @horner x c1f c2f c3f c4f c5f c6f c7f c8f c9f
 
-c9f = -0.00176397908944636583328247f0
-c8f =  0.0107900900766253471374512f0
-c7f = -0.0309564601629972457885742f0
-c6f =  0.0577365085482597351074219f0
-c5f = -0.0838950723409652709960938f0
-c4f =  0.109463557600975036621094f0
-c3f = -0.142626821994781494140625f0
-c2f =  0.199983194470405578613281f0
-c1f = -0.333332866430282592773438f0
+@inline function atan2k_fast(y::V, x::V) where {T<:Union{Float32,Float64},V<:Union{T,Vec{<:Any,T}}}
+    xl0 = x < 0
+    q = vifelse(xl0, -2, 0)
+    x = vifelse(xl0, -x, x)
+    ygx = y > x
+    t = x
+    x = vifelse(ygx, y, x)
+    y = vifelse(ygx, -t, y)
+    q = vifelse(ygx, q+1, q)
 
-global @inline atan2k_fast_kernel(x::Float64) = @horner x c1d c2d c3d c4d c5d c6d c7d c8d c9d c10d c11d c12d c13d c14d c15d c16d c17d c18d c19d c20d
-global @inline atan2k_fast_kernel(x::Float32) = @horner x c1f c2f c3f c4f c5f c6f c7f c8f c9f
-
-@inline function atan2k_fast(y::T, x::T) where {T<:Union{Float32,Float64}}
-    q = 0
-    if x < 0
-        x = -x
-        q = -2
-    end
-    if y > x
-        t = x; x = y
-        y = -t
-        q += 1
-    end
     s = y / x
     t = s * s
     u = atan2k_fast_kernel(t)
-    t = u * t * s + s
-    q * T(PI_2) + t
+    t = muladd(u, t * s, s)
+    muladd(q, T(PI_2), t)
 end
 
 
-global @inline atan2k_kernel(x::Double{Float64}) = @horner x.hi c1d c2d c3d c4d c5d c6d c7d c8d c9d c10d c11d c12d c13d c14d c15d c16d c17d c18d c19d c20d
-global @inline atan2k_kernel(x::Double{Float32}) = dadd(c1f, x.hi * (@horner x.hi c2f c3f c4f c5f c6f c7f c8f c9f))
+@inline atan2k_kernel(x::Double{<:FloatType64}) = @horner x.hi c1d c2d c3d c4d c5d c6d c7d c8d c9d c10d c11d c12d c13d c14d c15d c16d c17d c18d c19d c20d
+@inline atan2k_kernel(x::Double{<:FloatType32}) = dadd(c1f, x.hi * (@horner x.hi c2f c3f c4f c5f c6f c7f c8f c9f))
 
-@inline function atan2k(y::Double{T}, x::Double{T}) where {T<:Union{Float32,Float64}}
-    q = 0
-    if x < 0
-        x = -x
-        q = -2
-    end
-    if y > x
-        t = x; x = y
-        y = -t
-        q += 1
-    end
+@inline function atan2k(y::Double{V}, x::Double{V}) where {T,V<:Union{T,Vec{<:Any,T}}}
+    xl0 = x < 0
+    q = vifelse(xl0, -2, 0)
+    x = vifelse(xl0, -x, x)
+    ygx = y > x
+    t = x
+    x = vifelse(ygx, y, x)
+    y = vifelse(ygx, -t, y)
+    q = vifelse(ygx, q+1, q)
 
     s = ddiv(y, x)
     t = dsqu(s)
@@ -160,10 +166,9 @@ global @inline atan2k_kernel(x::Double{Float32}) = dadd(c1f, x.hi * (@horner x.h
 
     t = dmul(t, u)
     t = dmul(s, dadd(T(1.0), t))
-    T <: Float64 && abs(s.hi) < 1e-200 && (t = s)
-    t = dadd(dmul(T(q), MDPI2(T)), t)
+    T <: Float64 && (t = vifelse(abs(s.hi) < 1e-200, s, t))
+    t = dadd(dmul(V(q), MDPI2(T)), t)
     return t
-end
 end
 
 
@@ -171,7 +176,7 @@ end
 const under_expk(::Type{Float64}) = -1000.0
 const under_expk(::Type{Float32}) = -104f0
 
-@inline function expk_kernel(x::Float64)
+@inline function expk_kernel(x::FloatType64)
     c10 = 2.51069683420950419527139e-08
     c9  = 2.76286166770270649116855e-07
     c8  = 2.75572496725023574143864e-06
@@ -185,7 +190,7 @@ const under_expk(::Type{Float32}) = -104f0
     return @horner x c1 c2 c3 c4 c5 c6 c7 c8 c9 c10
 end
 
-@inline function  expk_kernel(x::Float32)
+@inline function  expk_kernel(x::FloatType32)
     c5 = 0.00136324646882712841033936f0
     c4 = 0.00836596917361021041870117f0
     c3 = 0.0416710823774337768554688f0
@@ -194,28 +199,28 @@ end
     return @horner x c1 c2 c3 c4 c5
 end
 
-@inline function expk(d::Double{T}) where {T<:Union{Float32,Float64}}
-    q = round(T(d) * T(MLN2E))
-    qi = unsafe_trunc(Int, q)
+@inline function expk(d::Double{V}) where {T<:Union{Float32,Float64},V<:Union{T,Vec{<:Any,T}}}
+    q = round(V(d) * V(MLN2E))
+    qi = unsafe_trunc(EquivalentInteger(T), q)
 
     s = dadd(d, -q * L2U(T))
     s = dadd(s, -q * L2L(T))
 
     s = dnormalize(s)
 
-    u = expk_kernel(T(s))
+    u = expk_kernel(V(s))
 
     t = dadd(s, dmul(dsqu(s), u))
     t = dadd(T(1.0), t)
-    u = ldexpk(T(t), qi)
+    u = ldexpk(V(t), qi)
 
-    (d.hi < under_expk(T)) && (u = T(0.0))
+    u = vifelse(d.hi < under_expk(T), V(0.0), u)
     return u
 end
 
 
 
-@inline function expk2_kernel(x::Double{Float64})
+@inline function expk2_kernel(x::Double{<:FloatType64})
     c11 = 0.1602472219709932072e-9
     c10  = 0.2092255183563157007e-8
     c9  = 0.2505230023782644465e-7
@@ -231,7 +236,7 @@ end
     return dadd(dmul(x, u), c1)
 end
 
-@inline function  expk2_kernel(x::Double{Float32})
+@inline function  expk2_kernel(x::Double{<:FloatType32})
     c5 = 0.1980960224f-3
     c4 = 0.1394256484f-2
     c3 = 0.8333456703f-2
@@ -241,7 +246,7 @@ end
     return dadd(dmul(x, u), c1)
 end
 
-@inline function expk2(d::Double{T}) where {T<:Union{Float32,Float64}}
+@inline function expk2(d::Double{V}) where {T<:Union{Float32,Float64},V<:Union{T,Vec{<:Any,T}}}
     q = round(T(d) * T(MLN2E))
     qi = unsafe_trunc(Int, q)
 
@@ -255,13 +260,13 @@ end
 
     t = Double(ldexp2k(t.hi, qi), ldexp2k(t.lo, qi))
 
-    (d.hi < under_expk(T)) && (t = Double(T(0.0)))
+    t = vifelse(d.hi < under_expk(T), Double(V(0.0)), t)
     return t
 end
 
 
 
-@inline function logk2_kernel(x::Float64)
+@inline function logk2_kernel(x::FloatType64)
     c8 = 0.13860436390467167910856
     c7 = 0.131699838841615374240845
     c6 = 0.153914168346271945653214
@@ -273,7 +278,7 @@ end
     return @horner x c1 c2 c3 c4 c5 c6 c7 c8
 end
 
-@inline function logk2_kernel(x::Float32)
+@inline function logk2_kernel(x::FloatType32)
     c4 = 0.240320354700088500976562f0
     c3 = 0.285112679004669189453125f0
     c2 = 0.400007992982864379882812f0
@@ -281,7 +286,7 @@ end
     return @horner x c1 c2 c3 c4
 end
 
-@inline function logk2(d::Double{T}) where {T<:Union{Float32,Float64}}
+@inline function logk2(d::Double{V}) where {T<:Union{Float32,Float64},V<:Union{T,Vec{<:Any,T}}}
     e  = ilogbk(d.hi * T(1.0/0.75))
     m  = scale(d, pow2i(T, -e))
 
@@ -298,7 +303,7 @@ end
 
 
 
-@inline function logk_kernel(x::Double{Float64})
+@inline function logk_kernel(x::Double{<:FloatType64})
     c10 = 0.116255524079935043668677
     c9 = 0.103239680901072952701192
     c8 = 0.117754809412463995466069
@@ -312,22 +317,23 @@ end
     dadd2(dmul(x, @horner x.hi c2 c3 c4 c5 c6 c7 c8 c9 c10), c1)
 end
 
-@inline function logk_kernel(x::Double{Float32})
+@inline function logk_kernel(x::Double{<:FloatType32})
     c4 = 0.240320354700088500976562f0
     c3 = 0.285112679004669189453125f0
     c2 = 0.400007992982864379882812f0
-    c1 = Double(0.66666662693023681640625f0, 3.69183861259614332084311f-9)    
+    c1 = Double(0.66666662693023681640625f0, 3.69183861259614332084311f-9)
     dadd2(dmul(x, @horner x.hi c2 c3 c4), c1)
 end
 
-@inline function logk(d::T) where {T<:Union{Float32,Float64}}
+@inline function logk(d::FloatType)
+    T = eltype(d)
     o = d < floatmin(T)
-    o && (d *= T(Int64(1) << 32) * T(Int64(1) << 32))
+    d = vifelse(o, d * T(Int64(1) << 32) * T(Int64(1) << 32), d)
 
     e  = ilogb2k(d * T(1.0/0.75))
     m  = ldexp3k(d, -e)
 
-    o && (e -= 64)
+    e = vifelse(o, e - 64, e)
 
     x  = ddiv(dsub2(m, T(1.0)), dadd2(T(1.0), m))
     x2 = dsqu(x)

--- a/src/priv.jl
+++ b/src/priv.jl
@@ -150,7 +150,11 @@ end
 
 @inline function atan2k(y::Double{V}, x::Double{V}) where {T,V<:Union{T,Vec{<:Any,T}}}
     xl0 = x < 0
-    q = vifelse(xl0, -2, 0)
+    if V <: Vec
+        q = vifelse(xl0, Vec{length(x.hi),EquivalentInteger(T)}(-2), 0)
+    else
+        q = vifelse(xl0, -2, 0)
+    end
     x = vifelse(xl0, -x, x)
     ygx = y > x
     t = x
@@ -167,7 +171,7 @@ end
     t = dmul(t, u)
     t = dmul(s, dadd(T(1.0), t))
     T <: Float64 && (t = vifelse(abs(s.hi) < 1e-200, s, t))
-    t = dadd(dmul(V(q), MDPI2(T)), t)
+    t = dadd(dmul(convert(V,q), MDPI2(T)), t)
     return t
 end
 
@@ -247,8 +251,8 @@ end
 end
 
 @inline function expk2(d::Double{V}) where {T<:Union{Float32,Float64},V<:Union{T,Vec{<:Any,T}}}
-    q = round(T(d) * T(MLN2E))
-    qi = unsafe_trunc(Int, q)
+    q = round(V(d) * T(MLN2E))
+    qi = unsafe_trunc(EquivalentInteger(T), q)
 
     s = dadd(d, -q * L2U(T))
     s = dadd(s, -q * L2L(T))
@@ -295,7 +299,7 @@ end
 
     t  = logk2_kernel(x2.hi)
 
-    s = dmul(MDLN2(T), T(e))
+    s = dmul(MDLN2(T), convert(V,e))
     s = dadd(s, scale(x, T(2.0)))
     s = dadd(s, dmul(dmul(x2, x), t))
     return s

--- a/src/trig.jl
+++ b/src/trig.jl
@@ -650,7 +650,7 @@ function tan_fast(d::FloatType32)
 end
 
 
-@inline function tan_kernel(x::Double{Float64})
+@inline function tan_kernel(x::Double{<:FloatType64})
     c15 = 1.01419718511083373224408e-05
     c14 = -2.59519791585924697698614e-05
     c13 = 5.23388081915899855325186e-05
@@ -680,11 +680,11 @@ end
     return dadd(c1,  x.hi * (@horner x.hi c2 c3 c4 c5 c6 c7))
 end
 
-function tan(d::FloatType64)
+function tan(d::V) where V <: FloatType64
     T = eltype(d)
     qh = trunc(d * (T(M_2_PI)) / (1 << 24))
-    s = dadd2(dmul(Double(T(M_2_PI_H), T(M_2_PI_L)), d), (d < 0 ? T(-0.5) : T(0.5)) - qh * (1 << 24))
-    ql = trunc(T(s))
+    s = dadd2(dmul(Double(T(M_2_PI_H), T(M_2_PI_L)), d), vifelse(d < 0, V(-0.5), V(0.5)) - qh * (1 << 24))
+    ql = trunc(V(s))
 
     s = dadd2(d, qh * (-PI_A(T) * T(0.5) * (1 << 24)))
     s = dadd2(s, ql * (-PI_A(T) * T(0.5)            ))
@@ -708,7 +708,7 @@ function tan(d::FloatType64)
 
     x = vifelse(qli_odd, drec(x), x)
 
-    v = T(x)
+    v = V(x)
 
     v = vifelse(
         (!isinf(d)) & (isnegzero(d) | (abs(d) > TRIG_MAX(T))),
@@ -718,7 +718,7 @@ function tan(d::FloatType64)
     return v
 end
 
-function tan(d::FloatType32)
+function tan(d::V) where V <: FloatType32
     T = eltype(d)
     q = round(d * (T(M_2_PI)))
 
@@ -743,7 +743,7 @@ function tan(d::FloatType32)
 
     x = vifelse(qli_odd, drec(x), x)
 
-    v = T(x)
+    v = V(x)
 
     v = vifelse(
         (!isinf(d)) & (isnegzero(d) | (abs(d) > TRIG_MAX(T))),
@@ -900,12 +900,13 @@ end
 
 Compute the inverse cosine of `x`, where the output is in radians.
 """
-function acos(x::T) where {T<:FloatType}
+function acos(x::V) where {V<:FloatType}
+    T = eltype(x)
     d = atan2k(dsqrt(dmul(dadd(T(1), x), dsub(T(1), x))), Double(abs(x)))
     d = flipsign(d, x)
     d = vifelse(abs(x) == 1, Double(T(0)), d)
     d = vifelse(signbit(x), dadd(MDPI(T), d), d)
-    return T(d)
+    return V(d)
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,25 +6,52 @@ for T in (Float32, Float64)
 end
 const FMA_FAST = is_fma_fast(Float64) && is_fma_fast(Float32)
 
-@inline isnegzero(x::T) where {T<:AbstractFloat} = x === T(-0.0)
+@inline isnegzero(x::T) where {T<:Union{Float32,Float64}} = x === T(-0.0)
+# Disabling the check for performance when vecterized.
+# My initial attempt at vectorizing the function failed.
+@inline isnegzero(x::Vec{N}) where N = Vec{N,Bool}(false)
+# @inline function isnegzero(x::Vec{N,T}) where {N,T<:Union{Float32,Float64}}
+#     Vec{N,Bool}(ntuple(Val(N)) do n
+#         x[n] === T(-0.0)
+#     end)
+# end
 
-@inline ispinf(x::T) where {T<:AbstractFloat} = x == T(Inf)
-@inline isninf(x::T) where {T<:AbstractFloat} = x == T(-Inf)
+@inline ispinf(x::T) where {T<:FloatType} = x == T(Inf)
+@inline isninf(x::T) where {T<:FloatType} = x == T(-Inf)
 
 # _sign emits better native code than sign but does not properly handle the Inf/NaN cases
-@inline _sign(d::T) where {T<:AbstractFloat} = flipsign(one(T), d)
+@inline _sign(d::T) where {T<:FloatType} = flipsign(one(T), d)
 
 @inline integer2float(::Type{Float64}, m::Int) = reinterpret(Float64, (m % Int64) << significand_bits(Float64))
 @inline integer2float(::Type{Float32}, m::Int) = reinterpret(Float32, (m % Int32) << significand_bits(Float32))
 
+@inline function integer2float(::Type{<:Union{Vec{N,Float64},Float64}}, m::Vec{N,Int}) where N
+    reinterpret(Vec{N,Float64}, Vec{N,Int64}(ntuple(Val(N)) do n
+        Core.VecElement(m[n] % Int64)
+    end) << significand_bits(Float64))
+end
+@inline function integer2float(::Type{<:Union{Vec{N,Float32},Float32}}, m::Vec{N,Int32}) where N
+    reinterpret(Vec{N,Float32}, Vec{N,Int32}(ntuple(Val(N)) do n
+        Core.VecElement(m[n] % Int32)
+    end) << Int32(significand_bits(Float32)))
+end
+
 @inline float2integer(d::Float64) = (reinterpret(Int64, d) >> significand_bits(Float64)) % Int
 @inline float2integer(d::Float32) = (reinterpret(Int32, d) >> significand_bits(Float32)) % Int
 
-@inline pow2i(::Type{T}, q::Int) where {T<:Union{Float32,Float64}} = integer2float(T, q + exponent_bias(T))
+@inline function float2integer(d::Vec{N,Float64}) where N
+    Vec{N,Int64}(ntuple(Val(N)) do n
+        Core.VecElement((reinterpret(Int64, d[n]) >> significand_bits(Float64)) % Int)
+    end)
+end
+@inline function float2integer(d::Vec{N,Float32}) where N
+    Vec{N,Int32}(ntuple(Val(N)) do n
+        Core.VecElement((reinterpret(Int32, d[n]) >> Int32(significand_bits(Float32))) % Int32)
+    end)
+end
+
+@inline pow2i(::Type{T}, q::I) where {T<:Union{Float32,Float64},I<:IntegerType} = integer2float(T, q + exponent_bias(T))
 
 # sqrt without the domain checks which we don't need since we handle the checks ourselves
-if VERSION < v"0.7-"
-    _sqrt(x::T) where {T<:Union{Float32,Float64}} = Base.sqrt_llvm_fast(x)
-else
-    _sqrt(x::T) where {T<:Union{Float32,Float64}} = Base.sqrt_llvm(x)
-end
+@inline _sqrt(x::T) where {T<:Union{Float32,Float64}} = Base.sqrt_llvm(x)
+@inline _sqrt(x::Vec) = sqrt(x)


### PR DESCRIPTION
- [ ] Add tests for Vec{N,T} where T <: FloatTypes.
- [ ] Make sure all of these tests also pass.
- [ ] Investigate performance regressions vs the SLEEF C library.

Overview of this PR:
The C SLEEF (SIMD Library for Evaluating Elementary Functions) library provides vectorized elementary functions. Therefore, I thought it makes sense to let `SLEEF.jl` support the `SIMD.jl`'s `Vec{N,T}` vector type.

This PR provides preliminary support.
```julia
using SIMD, SLEEF, SLEEFwrap, BenchmarkTools, Random
@inline extract(x) = x.elts # 64-byte vectors segfault when returned while wrapped in a struct
sv8 = Vec{8,Float32}(ntuple(Val(8)) do x Core.VecElement(randexp(Float32)) end)
dv4 = Vec{4,Float64}(ntuple(Val(4)) do x Core.VecElement(randexp(Float64)) end)
sv16 = Vec{16,Float32}(ntuple(Val(16)) do x Core.VecElement(randexp(Float32)) end)
dv8 = Vec{8,Float64}(ntuple(Val(8)) do x Core.VecElement(randexp(Float64)) end)
function bench(jl, c, x)
    display(@benchmark extract($jl($x)))
    display(@benchmark $c(extract($x)))
end
```
Testing a bunch of functions:
`exp`:
```julia
julia> bench(SLEEF.exp, SLEEFwrap.exp, sv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     5.545 ns (0.00% GC)
  median time:      5.686 ns (0.00% GC)
  mean time:        5.816 ns (0.00% GC)
  maximum time:     23.974 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     4.689 ns (0.00% GC)
  median time:      4.722 ns (0.00% GC)
  mean time:        4.740 ns (0.00% GC)
  maximum time:     23.272 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> bench(SLEEF.exp, SLEEFwrap.exp, dv4)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     7.408 ns (0.00% GC)
  median time:      7.449 ns (0.00% GC)
  mean time:        7.467 ns (0.00% GC)
  maximum time:     24.513 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     6.615 ns (0.00% GC)
  median time:      6.722 ns (0.00% GC)
  mean time:        6.737 ns (0.00% GC)
  maximum time:     20.488 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> bench(SLEEF.exp, SLEEFwrap.exp, sv16)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4677168108795565027
  --------------
  minimum time:     5.691 ns (0.00% GC)
  median time:      5.731 ns (0.00% GC)
  mean time:        5.779 ns (0.00% GC)
  maximum time:     22.034 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4677168108795565027
  --------------
  minimum time:     5.256 ns (0.00% GC)
  median time:      5.287 ns (0.00% GC)
  mean time:        5.297 ns (0.00% GC)
  maximum time:     14.432 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> bench(SLEEF.exp, SLEEFwrap.exp, dv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4613273474792594525
  --------------
  minimum time:     7.284 ns (0.00% GC)
  median time:      7.321 ns (0.00% GC)
  mean time:        7.336 ns (0.00% GC)
  maximum time:     25.833 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4613273474792594525
  --------------
  minimum time:     11.036 ns (0.00% GC)
  median time:      11.553 ns (0.00% GC)
  mean time:        11.370 ns (0.00% GC)
  maximum time:     38.117 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
`log`
```julia

```
julia> bench(SLEEF.log, SLEEFwrap.log, sv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     15.225 ns (0.00% GC)
  median time:      15.276 ns (0.00% GC)
  mean time:        15.310 ns (0.00% GC)
  maximum time:     31.264 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.967 ns (0.00% GC)
  median time:      10.042 ns (0.00% GC)
  mean time:        10.065 ns (0.00% GC)
  maximum time:     32.280 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.log, SLEEFwrap.log, dv4)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     16.762 ns (0.00% GC)
  median time:      16.993 ns (0.00% GC)
  mean time:        16.964 ns (0.00% GC)
  maximum time:     30.792 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     12.829 ns (0.00% GC)
  median time:      12.873 ns (0.00% GC)
  mean time:        12.897 ns (0.00% GC)
  maximum time:     27.613 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.log, SLEEFwrap.log, sv16)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4552958378306737260
  --------------
  minimum time:     16.331 ns (0.00% GC)
  median time:      16.536 ns (0.00% GC)
  mean time:        16.543 ns (0.00% GC)
  maximum time:     42.043 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4552958378306737260
  --------------
  minimum time:     8.060 ns (0.00% GC)
  median time:      8.115 ns (0.00% GC)
  mean time:        8.130 ns (0.00% GC)
  maximum time:     31.205 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.log, SLEEFwrap.log, dv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  -4651049139759164439
  --------------
  minimum time:     18.395 ns (0.00% GC)
  median time:      18.477 ns (0.00% GC)
  mean time:        18.613 ns (0.00% GC)
  maximum time:     45.013 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  -4651049139759164439
  --------------
  minimum time:     11.021 ns (0.00% GC)
  median time:      11.084 ns (0.00% GC)
  mean time:        11.114 ns (0.00% GC)
  maximum time:     35.427 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
`sin`
```julia
julia> bench(SLEEF.sin, SLEEFwrap.sin, sv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     19.354 ns (0.00% GC)
  median time:      19.471 ns (0.00% GC)
  mean time:        19.612 ns (0.00% GC)
  maximum time:     37.226 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.906 ns (0.00% GC)
  median time:      9.953 ns (0.00% GC)
  mean time:        9.972 ns (0.00% GC)
  maximum time:     21.988 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.sin, SLEEFwrap.sin, dv4)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     28.163 ns (0.00% GC)
  median time:      28.265 ns (0.00% GC)
  mean time:        28.329 ns (0.00% GC)
  maximum time:     52.633 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     10.484 ns (0.00% GC)
  median time:      10.541 ns (0.00% GC)
  mean time:        10.568 ns (0.00% GC)
  maximum time:     27.162 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.sin, SLEEFwrap.sin, sv16)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4569599948461514222
  --------------
  minimum time:     20.364 ns (0.00% GC)
  median time:      20.458 ns (0.00% GC)
  mean time:        20.502 ns (0.00% GC)
  maximum time:     47.938 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4569599948461514222
  --------------
  minimum time:     10.426 ns (0.00% GC)
  median time:      10.565 ns (0.00% GC)
  mean time:        10.587 ns (0.00% GC)
  maximum time:     33.371 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> bench(SLEEF.sin, SLEEFwrap.sin, dv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4605730538145129761
  --------------
  minimum time:     28.796 ns (0.00% GC)
  median time:      28.919 ns (0.00% GC)
  mean time:        29.123 ns (0.00% GC)
  maximum time:     55.898 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4605730538145129761
  --------------
  minimum time:     11.913 ns (0.00% GC)
  median time:      12.026 ns (0.00% GC)
  mean time:        12.050 ns (0.00% GC)
  maximum time:     33.233 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
`tan`
```julia
julia> bench(SLEEF.tan, SLEEFwrap.tan, sv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     36.797 ns (0.00% GC)
  median time:      36.895 ns (0.00% GC)
  mean time:        36.988 ns (0.00% GC)
  maximum time:     58.675 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     992
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     16.273 ns (0.00% GC)
  median time:      16.346 ns (0.00% GC)
  mean time:        16.381 ns (0.00% GC)
  maximum time:     34.868 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998

julia> bench(SLEEF.tan, SLEEFwrap.tan, dv4)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     51.512 ns (0.00% GC)
  median time:      51.640 ns (0.00% GC)
  mean time:        52.010 ns (0.00% GC)
  maximum time:     73.956 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     986
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     14.053 ns (0.00% GC)
  median time:      14.161 ns (0.00% GC)
  mean time:        14.179 ns (0.00% GC)
  maximum time:     31.734 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998

julia> bench(SLEEF.tan, SLEEFwrap.tan, sv16)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  -4606600161933539213
  --------------
  minimum time:     38.064 ns (0.00% GC)
  median time:      38.202 ns (0.00% GC)
  mean time:        38.285 ns (0.00% GC)
  maximum time:     62.710 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     992
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  -4606600161933539213
  --------------
  minimum time:     18.630 ns (0.00% GC)
  median time:      18.712 ns (0.00% GC)
  mean time:        18.756 ns (0.00% GC)
  maximum time:     44.121 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997

julia> bench(SLEEF.tan, SLEEFwrap.tan, dv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4609617611958208877
  --------------
  minimum time:     55.713 ns (0.00% GC)
  median time:      55.881 ns (0.00% GC)
  mean time:        56.035 ns (0.00% GC)
  maximum time:     78.817 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     984
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4609617611958208877
  --------------
  minimum time:     17.800 ns (0.00% GC)
  median time:      17.898 ns (0.00% GC)
  mean time:        18.053 ns (0.00% GC)
  maximum time:     42.916 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
```
`cbrt`
```julia
julia> bench(SLEEF.cbrt, SLEEFwrap.cbrt, sv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     31.845 ns (0.00% GC)
  median time:      32.018 ns (0.00% GC)
  mean time:        32.143 ns (0.00% GC)
  maximum time:     54.500 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     994
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     25.222 ns (0.00% GC)
  median time:      26.324 ns (0.00% GC)
  mean time:        26.364 ns (0.00% GC)
  maximum time:     43.927 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     996

julia> bench(SLEEF.cbrt, SLEEFwrap.cbrt, dv4)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     36.175 ns (0.00% GC)
  median time:      36.303 ns (0.00% GC)
  mean time:        36.564 ns (0.00% GC)
  maximum time:     57.701 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     993
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     28.349 ns (0.00% GC)
  median time:      29.205 ns (0.00% GC)
  mean time:        29.250 ns (0.00% GC)
  maximum time:     46.513 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995

julia> bench(SLEEF.cbrt, SLEEFwrap.cbrt, sv16)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4584898609104978811
  --------------
  minimum time:     34.463 ns (0.00% GC)
  median time:      34.570 ns (0.00% GC)
  mean time:        34.634 ns (0.00% GC)
  maximum time:     58.556 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     993
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4584898609104978811
  --------------
  minimum time:     23.273 ns (0.00% GC)
  median time:      25.731 ns (0.00% GC)
  mean time:        25.492 ns (0.00% GC)
  maximum time:     50.618 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     996

julia> bench(SLEEF.cbrt, SLEEFwrap.cbrt, dv8)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4607167657796590655
  --------------
  minimum time:     42.291 ns (0.00% GC)
  median time:      42.392 ns (0.00% GC)
  mean time:        42.476 ns (0.00% GC)
  maximum time:     65.205 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     990
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  4607167657796590655
  --------------
  minimum time:     26.524 ns (0.00% GC)
  median time:      26.741 ns (0.00% GC)
  mean time:        26.800 ns (0.00% GC)
  maximum time:     46.431 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995
```
Performance is currently often 2 or 3x worse than `SLEEFwrap.jl` (which wraps the C library).